### PR TITLE
docker image address is incorrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ $ badrobot scan operator.yaml
 Run the same command in Docker:
 
 ```bash
-$ docker run -i controlplaneio/badrobot scan /dev/stdin < operator.yaml
+$ docker run -i controlplane/badrobot scan /dev/stdin < operator.yaml
 ```
 
 ## Rulesets


### PR DESCRIPTION
the docker image in docker hub is under `controlplane` not `controlplaneio`;

```
❯ docker pull controlplane/badrobot
Using default tag: latest
latest: Pulling from controlplane/badrobot
Digest: sha256:3fe16502ac8e377b71f136c13a918dc0caf6d4e76efcfe47ee82e099bf9b9c37
Status: Image is up to date for controlplane/badrobot:latest
docker.io/controlplane/badrobot:latest
```

vs

```
❯ docker pull controlplaneio/badrobot
Using default tag: latest
Error response from daemon: pull access denied for controlplaneio/badrobot, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
```