### PR TITLE
Add missing wildcard checks in existing rules and update the nodes/proxy rule based on latest research

### DIFF
--- a/pkg/rules/admissionControllerClusterRole.go
+++ b/pkg/rules/admissionControllerClusterRole.go
@@ -17,8 +17,8 @@ func AdmissionControllerClusterRole(input []byte) int {
 	}
 
 	for _, rule := range clusterRole.Rules {
-		if contains("admissionregistration.k8s.io", rule.APIGroups) &&
-			containsAny([]string{"mutatingwebhookconfigurations", "validatingwebhookconfigurations"}, rule.Resources) &&
+		if containsAny([]string{"*", "admissionregistration.k8s.io"}, rule.APIGroups) &&
+			containsAny([]string{"*", "mutatingwebhookconfigurations", "validatingwebhookconfigurations"}, rule.Resources) &&
 			containsAny([]string{"*", "create", "patch", "update", "delete", "deletecollection"}, rule.Verbs) {
 			rbac++
 		}

--- a/pkg/rules/bindClusterRole.go
+++ b/pkg/rules/bindClusterRole.go
@@ -17,9 +17,9 @@ func BindClusterRole(input []byte) int {
 	}
 
 	for _, rule := range clusterRole.Rules {
-		if contains("rbac.authorization.k8s.io", rule.APIGroups) &&
-			contains("clusterroles", rule.Resources) &&
-			contains("bind", rule.Verbs) {
+		if containsAny([]string{"*", "rbac.authorization.k8s.io"}, rule.APIGroups) &&
+			containsAny([]string{"*", "clusterroles"}, rule.Resources) &&
+			containsAny([]string{"*", "bind"}, rule.Verbs) {
 			rbac++
 		}
 	}

--- a/pkg/rules/customResourceClusterRole.go
+++ b/pkg/rules/customResourceClusterRole.go
@@ -17,8 +17,8 @@ func CustomResourceClusterRole(input []byte) int {
 	}
 
 	for _, rule := range clusterRole.Rules {
-		if contains("apiextensions.k8s.io", rule.APIGroups) &&
-			contains("customresourcedefinitions", rule.Resources) &&
+		if containsAny([]string{"*", "apiextensions.k8s.io"}, rule.APIGroups) &&
+			containsAny([]string{"*", "customresourcedefinitions"}, rule.Resources) &&
 			containsAny([]string{"*", "create", "patch", "update", "delete", "deletecollection"}, rule.Verbs) {
 			rbac++
 		}

--- a/pkg/rules/escalateClusterRole.go
+++ b/pkg/rules/escalateClusterRole.go
@@ -17,9 +17,9 @@ func EscalateClusterRole(input []byte) int {
 	}
 
 	for _, rule := range clusterRole.Rules {
-		if contains("rbac.authorization.k8s.io", rule.APIGroups) &&
-			contains("clusterroles", rule.Resources) &&
-			contains("escalate", rule.Verbs) {
+		if containsAny([]string{"*", "rbac.authorization.k8s.io"}, rule.APIGroups) &&
+			containsAny([]string{"*", "clusterroles"}, rule.Resources) &&
+			containsAny([]string{"*", "escalate"}, rule.Verbs) {
 			rbac++
 		}
 	}

--- a/pkg/rules/execPodsClusterRole.go
+++ b/pkg/rules/execPodsClusterRole.go
@@ -19,19 +19,19 @@ func ExecPodsClusterRole(input []byte) int {
 	}
 
 	for _, rule := range clusterRole.Rules {
-		if contains("", rule.APIGroups) &&
+		if containsAny([]string{"*", ""}, rule.APIGroups) &&
 			containsAll([]string{"pods", "pods/exec"}, rule.Resources) &&
 			(contains("*", rule.Verbs) || containsAll([]string{"get", "create"}, rule.Verbs)) {
 			rbac++
-		} else if contains("", rule.APIGroups) &&
-			contains("pods", rule.Resources) &&
+		} else if containsAny([]string{"*", ""}, rule.APIGroups) &&
+			containsAny([]string{"*", "pods"}, rule.Resources) &&
 			containsAny([]string{"*", "get"}, rule.Verbs) {
 			foundPodsGet = true
 			if foundPodsGet && foundExecCreate {
 				rbac++
 			}
-		} else if contains("", rule.APIGroups) &&
-			contains("pods/exec", rule.Resources) &&
+		} else if containsAny([]string{"*", ""}, rule.APIGroups) &&
+			containsAny([]string{"*", "pods/exec"}, rule.Resources) &&
 			containsAny([]string{"*", "create"}, rule.Verbs) {
 			foundExecCreate = true
 			if foundPodsGet && foundExecCreate {

--- a/pkg/rules/impersonateClusterRole.go
+++ b/pkg/rules/impersonateClusterRole.go
@@ -18,8 +18,8 @@ func ImpersonateClusterRole(input []byte) int {
 
 	for _, rule := range clusterRole.Rules {
 		if containsAny([]string{"", "*"}, rule.APIGroups) &&
-			contains("serviceaccounts", rule.Resources) &&
-			contains("impersonate", rule.Verbs) {
+			containsAny([]string{"serviceaccounts", "groups", "*"}, rule.Resources) &&
+			containsAny([]string{"*", "impersonate"}, rule.Verbs) {
 			rbac++
 		}
 	}

--- a/pkg/rules/modifyPodLogsClusterRole.go
+++ b/pkg/rules/modifyPodLogsClusterRole.go
@@ -17,8 +17,8 @@ func ModifyPodLogsClusterRole(input []byte) int {
 	}
 
 	for _, rule := range clusterRole.Rules {
-		if contains("", rule.APIGroups) &&
-			contains("pods/log", rule.Resources) &&
+		if containsAny([]string{"*", ""}, rule.APIGroups) &&
+			containsAny([]string{"*", "pods/log"}, rule.Resources) &&
 			containsAny([]string{"*", "create", "patch", "update", "delete", "deletecollection"}, rule.Verbs) {
 			rbac++
 		}

--- a/pkg/rules/networkPolicyClusterRole.go
+++ b/pkg/rules/networkPolicyClusterRole.go
@@ -17,7 +17,7 @@ func NetworkPolicyClusterRole(input []byte) int {
 	}
 
 	for _, rule := range clusterRole.Rules {
-		if contains("networking.k8s.io", rule.APIGroups) &&
+		if containsAny([]string{"*", "networking.k8s.io"}, rule.APIGroups) &&
 			containsAny([]string{"networkpolicy", "networkpolicies", "*"}, rule.Resources) &&
 			containsAny([]string{"*", "create", "update", "patch", "delete", "deletecollection"}, rule.Verbs) {
 			rbac++

--- a/pkg/rules/nodeProxyClusterRole.go
+++ b/pkg/rules/nodeProxyClusterRole.go
@@ -17,13 +17,9 @@ func NodeProxyClusterRole(input []byte) int {
 	}
 
 	for _, rule := range clusterRole.Rules {
-		if contains("", rule.APIGroups) &&
-			contains("nodes/proxy", rule.Resources) &&
-			contains("*", rule.Verbs) {
-			rbac++
-		} else if contains("", rule.APIGroups) &&
-			contains("nodes/proxy", rule.Resources) &&
-			containsAll([]string{"get", "create"}, rule.Verbs) {
+		if containsAny([]string{"*", ""}, rule.APIGroups) &&
+			containsAny([]string{"*", "nodes/proxy"}, rule.Resources) &&
+			containsAny([]string{"*", "get"}, rule.Verbs) {
 			rbac++
 		}
 	}

--- a/pkg/rules/persistentVolumesClusterRole.go
+++ b/pkg/rules/persistentVolumesClusterRole.go
@@ -18,18 +18,18 @@ func PersistentVolumeClusterRole(input []byte) int {
 	}
 
 	for _, rule := range clusterRole.Rules {
-		if contains("", rule.APIGroups) &&
-			containsAll([]string{"persistentvolumes", "persistentvolumeclaims"}, rule.Resources) &&
+		if containsAny([]string{"*", ""}, rule.APIGroups) &&
+			(containsAll([]string{"persistentvolumes", "persistentvolumeclaims"}, rule.Resources) || contains("*", rule.Resources)) &&
 			containsAny([]string{"*", "get", "list", "create", "patch", "update", "delete", "deletecollection", "watch"}, rule.Verbs) {
 			rbac++
-		} else if contains("", rule.APIGroups) &&
+		} else if containsAny([]string{"*", ""}, rule.APIGroups) &&
 			contains("persistentvolumes", rule.Resources) &&
 			containsAny([]string{"*", "get", "list", "create", "patch", "update", "delete", "deletecollection", "watch"}, rule.Verbs) {
 			foundPV = true
 			if foundPV && foundPVC {
 				rbac++
 			}
-		} else if contains("", rule.APIGroups) &&
+		} else if containsAny([]string{"*", ""}, rule.APIGroups) &&
 			contains("persistentvolumeclaims", rule.Resources) &&
 			containsAny([]string{"*", "get", "list", "create", "patch", "update", "delete", "deletecollection", "watch"}, rule.Verbs) {
 			foundPVC = true

--- a/pkg/rules/removeEventsClusterRole.go
+++ b/pkg/rules/removeEventsClusterRole.go
@@ -17,8 +17,8 @@ func RemoveEventsClusterRole(input []byte) int {
 	}
 
 	for _, rule := range clusterRole.Rules {
-		if contains("", rule.APIGroups) &&
-			contains("events", rule.Resources) &&
+		if containsAny([]string{"*", ""}, rule.APIGroups) &&
+			containsAny([]string{"*", "events"}, rule.Resources) &&
 			containsAny([]string{"*", "delete", "deletecollection"}, rule.Verbs) {
 			rbac++
 		}

--- a/pkg/rules/secretsClusterRole.go
+++ b/pkg/rules/secretsClusterRole.go
@@ -17,8 +17,8 @@ func SecretsClusterRole(input []byte) int {
 	}
 
 	for _, rule := range clusterRole.Rules {
-		if contains("", rule.APIGroups) &&
-			contains("secrets", rule.Resources) &&
+		if containsAny([]string{"*", ""}, rule.APIGroups) &&
+			containsAny([]string{"*", "secrets"}, rule.Resources) &&
 			containsAny([]string{"*", "get", "create", "update", "list", "patch", "watch"}, rule.Verbs) {
 			rbac++
 		}

--- a/pkg/rules/serviceAccountClusterRole.go
+++ b/pkg/rules/serviceAccountClusterRole.go
@@ -17,8 +17,8 @@ func ServiceAccountClusterRole(input []byte) int {
 	}
 
 	for _, rule := range clusterRole.Rules {
-		if contains("", rule.APIGroups) &&
-			contains("serviceaccounts/token", rule.Resources) &&
+		if containsAny([]string{"*", ""}, rule.APIGroups) &&
+			containsAny([]string{"*", "serviceaccounts/token"}, rule.Resources) &&
 			containsAny([]string{"*", "create"}, rule.Verbs) {
 			rbac++
 		}

--- a/test/1_cli.bats
+++ b/test/1_cli.bats
@@ -218,12 +218,6 @@ teardown() {
   assert_zero_points
 }
 
-# CoreAPI Limited verbs
-@test "passes ClusterRole has access to CoreAPI with limited verbs defined" {
-  run _app "${TEST_DIR}/asset/cr-coreapi-limited-verbs.yaml"
-  assert_zero_points
-}
-
 # Non-CoreAPI Limited Resources
 @test "passes ClusterRole has access to Non-CoreAPI with limited resources defined" {
   run _app "${TEST_DIR}/asset/cr-noncoreapi-limited.yaml"
@@ -246,12 +240,6 @@ teardown() {
 @test "fails ClusterRole has full access to CoreAPI defined (all verbs)" {
   run _app "${TEST_DIR}/asset/cr-coreapi-all-verbs.yaml"
   assert_lt_zero_points
-}
-
-# Only full access to ClusterRoles
-@test "passes ClusterRole only has full access to ClusterRoles" {
-  run _app "${TEST_DIR}/asset/cr-all-clusterroles-only.yaml"
-  assert_zero_points
 }
 
 # Only full access to ClusterRoleBindings
@@ -288,6 +276,12 @@ teardown() {
 # OPR-R14-RBAC
 @test "fails ClusterRole has access to Kubernetes secrets (all verbs)" {
   run _app "${TEST_DIR}/asset/cr-secrets-all-verbs.yaml"
+  assert_lt_zero_points
+}
+
+# OPR-R14-RBAC
+@test "fails ClusterRole has access to Kubernetes secrets (star resources)" {
+  run _app "${TEST_DIR}/asset/cr-coreapi-limited-verbs.yaml"
   assert_lt_zero_points
 }
 
@@ -369,15 +363,33 @@ teardown() {
   assert_lt_zero_points
 }
 
+# OPR-R16-RBAC
+@test "fails ClusterRole has escalate permissions (star)" {
+  run _app "${TEST_DIR}/asset/cr-all-clusterroles-only.yaml"
+  assert_lt_zero_points
+}
+
 # OPR-R17-RBAC
 @test "fails ClusterRole has bind permissions" {
   run _app "${TEST_DIR}/asset/cr-bind.yaml"
   assert_lt_zero_points
 }
 
+# OPR-R17-RBAC
+@test "fails ClusterRole has bind permissions (star)" {
+  run _app "${TEST_DIR}/asset/cr-all-clusterroles-only.yaml"
+  assert_lt_zero_points
+}
+
 # OPR-R18-RBAC
 @test "fails ClusterRole has impersonate permissions" {
   run _app "${TEST_DIR}/asset/cr-impersonate.yaml"
+  assert_lt_zero_points
+}
+
+# OPR-R23-RBAC
+@test "fails ClusterRole has impersonate permissions (star)" {
+  run _app "${TEST_DIR}/asset/cr-sa-star.yaml"
   assert_lt_zero_points
 }
 
@@ -472,12 +484,6 @@ teardown() {
 }
 
 # OPR-R23-RBAC
-@test "passes ClusterRole has full permissions over service accounts (star)" {
-  run _app "${TEST_DIR}/asset/cr-sa-star.yaml"
-  assert_zero_points
-}
-
-# OPR-R23-RBAC
 @test "passes ClusterRole has full permissions over service accounts (verbs)" {
   run _app "${TEST_DIR}/asset/cr-sa-verbs.yaml"
   assert_zero_points
@@ -510,6 +516,12 @@ teardown() {
 # OPR-R24-RBAC
 @test "fails ClusterRole has read, write or delete permissions over persistent volume claim (separate)" {
   run _app "${TEST_DIR}/asset/cr-pvc-separate-resources.yaml"
+  assert_lt_zero_points
+}
+
+# OPR-R24-RBAC
+@test "fails ClusterRole has read, write or delete permissions over persistent volume claim (star resources)" {
+  run _app "${TEST_DIR}/asset/cr-coreapi-limited-verbs.yaml"
   assert_lt_zero_points
 }
 
@@ -582,6 +594,12 @@ teardown() {
 # OPR-R26-RBAC
 @test "fails ClusterRole has permissions over node proxy (verbs)" {
   run _app "${TEST_DIR}/asset/cr-node-proxy-verbs.yaml"
+  assert_lt_zero_points
+}
+
+# OPR-R26-RBAC
+@test "fails ClusterRole has permissions over node proxy (star resources)" {
+  run _app "${TEST_DIR}/asset/cr-coreapi-limited-verbs.yaml"
   assert_lt_zero_points
 }
 

--- a/test/asset/cr-node-verbs.yaml
+++ b/test/asset/cr-node-verbs.yaml
@@ -9,4 +9,3 @@ rules:
   - nodes
   verbs:
   - get
-  - create


### PR DESCRIPTION
- Updates the `nodes/proxy` rule - `get` permissions for `nodes/proxy` are sufficient to be able to execute commands in pods based on latest research (https://grahamhelton.com/blog/nodes-proxy-rce)
- Add missing checks for wildcards in multiple existing rules - lack of checks for wildcards may lead to missing some edge cases